### PR TITLE
Fix ambiguous call to charly_create_number

### DIFF
--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -775,7 +775,7 @@ VALUE VM::readmembersymbol(VALUE source, VALUE symbol) {
       }
 
       if (symbol == SYM("thread_policy")) {
-        return charly_create_number(cfunc->get_thread_policy());
+        return charly_create_number(static_cast<uint8_t>(cfunc->get_thread_policy()));
       }
 
       VALUE value;


### PR DESCRIPTION
This is a compiler error without the explicit cast:

```
src/vm/vm.cpp:778:16: error: call to 'charly_create_number' is ambiguous
        return charly_create_number(cfunc->get_thread_policy());
               ^~~~~~~~~~~~~~~~~~~~
include/value.h:1065:14: note: candidate function
inline VALUE charly_create_number(int32_t value)  { return charly_create_integer(value); }
             ^
include/value.h:1075:14: note: candidate function
inline VALUE charly_create_number(uint8_t value)  { return charly_create_integer(value); }
             ^
include/value.h:1046:14: note: candidate function
inline VALUE charly_create_number(int64_t value) {
             ^
include/value.h:1051:14: note: candidate function
inline VALUE charly_create_number(uint64_t value) {
             ^
include/value.h:1067:14: note: candidate function
inline VALUE charly_create_number(uint32_t value) { return charly_create_integer(value); }
             ^
include/value.h:1069:14: note: candidate function
inline VALUE charly_create_number(int16_t value)  { return charly_create_integer(value); }
             ^
include/value.h:1071:14: note: candidate function
inline VALUE charly_create_number(uint16_t value) { return charly_create_integer(value); }
             ^
include/value.h:1073:14: note: candidate function
inline VALUE charly_create_number(int8_t value)   { return charly_create_integer(value); }
             ^
include/value.h:1077:14: note: candidate function
inline VALUE charly_create_number(double value)   {
             ^
include/value.h:1085:14: note: candidate function
inline VALUE charly_create_number(float value)    { return charly_create_number((double)value); }
```